### PR TITLE
receptor as list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ sms = ghasedak.Ghasedak("Your APIKEY")
 
 sms.send({'message':'hello, world!', 'receptor' : '09xxxxxxxxx', 'linenumber': 'xxxx', 'senddate': '', 'checkid': ''})
 
-sms.bulk1({'message':'hello, world!', 'receptor' : '09xxxxxxxxx,09xxxxxxxxx,09xxxxxxxxx', 'linenumber': 'xxxx', 'senddate': '', 'checkid': ''})
+sms.bulk1({'message':'hello, world!', 'receptor' : ['09xxxxxxxxx','09xxxxxxxxx','09xxxxxxxxx'], 'linenumber': 'xxxx', 'senddate': '', 'checkid': ''})
 ```
 
 ## license


### PR DESCRIPTION
receptor as a string raise this error : 
 {"result":{"code":419,"message":"error! ArrayLengthError"},"items":[4]}
use it as list.